### PR TITLE
Removed SO_REUSEPORT: identical to SO_REUSEADDR for unix sockets and …

### DIFF
--- a/lib/ssdp.rb
+++ b/lib/ssdp.rb
@@ -48,7 +48,6 @@ module SSDP
     membership = IPAddr.new(options[:broadcast]).hton + IPAddr.new(options[:bind]).hton
     listener.setsockopt Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership
     listener.setsockopt Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true
-    listener.setsockopt Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true
     listener.bind options[:bind], options[:port]
     listener
   end


### PR DESCRIPTION
…breaking on windows. Detailed explanations here: https://github.com/jpignata/backchannel/issues/2.
