### PR TITLE
SO_REUSE* cross-platform

### DIFF
--- a/lib/ssdp.rb
+++ b/lib/ssdp.rb
@@ -48,6 +48,9 @@ module SSDP
     membership = IPAddr.new(options[:broadcast]).hton + IPAddr.new(options[:bind]).hton
     listener.setsockopt Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership
     listener.setsockopt Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true
+    if defined? Socket::SO_REUSEPORT
+      listener.setsockopt Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true
+    end
     listener.bind options[:bind], options[:port]
     listener
   end

--- a/ssdp.gemspec
+++ b/ssdp.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.name                  = 'ssdp'
   spec.platform              = Gem::Platform::RUBY
   spec.require_paths         = ['lib']
-  spec.version               = '1.1.3'
+  spec.version               = '1.1.4'
   spec.license               = 'BSD 2-Clause'
   spec.summary               = 'SSDP client/server library.'
   spec.description           = 'SSDP client/server library. Server notify/part/respond; client search/listen.'


### PR DESCRIPTION
Instead of completely removing this line, going to apply it conditionally.
Maintain functionality with OSX (and probably *-BSD).
Update version for new release (1.1.4).
Tested against OSX, Win7, and Debian Jessie.
