### PR TITLE
Modified reference to Socket constants for JRuby compatibility

### DIFF
--- a/lib/ssdp.rb
+++ b/lib/ssdp.rb
@@ -59,7 +59,7 @@ module SSDP
   def create_broadcaster
     broadcaster = UDPSocket.new
     broadcaster.setsockopt Socket::SOL_SOCKET, Socket::SO_BROADCAST, true
-    broadcaster.setsockopt :IPPROTO_IP, :IP_MULTICAST_TTL, 1
+    broadcaster.setsockopt Socket::IPPROTO_IP, Socket::IP_MULTICAST_TTL, 1
     broadcaster
   end
   module_function :create_broadcaster

--- a/ssdp.gemspec
+++ b/ssdp.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.name                  = 'ssdp'
   spec.platform              = Gem::Platform::RUBY
   spec.require_paths         = ['lib']
-  spec.version               = '1.1.5'
+  spec.version               = '1.1.6'
   spec.license               = 'BSD 2-Clause'
   spec.summary               = 'SSDP client/server library.'
   spec.description           = 'SSDP client/server library. Server notify/part/respond; client search/listen.'


### PR DESCRIPTION
This change fix this exception in JRuby
```Java::JavaLang::IllegalArgumentException: No enum constant jnr.constants.platform.SocketLevel.SOL_IPPROTO_IP```