### PR TITLE
set IP_MULTICAST_IF to support multihomed clients

### DIFF
--- a/lib/ssdp.rb
+++ b/lib/ssdp.rb
@@ -56,10 +56,11 @@ module SSDP
   end
   module_function :create_listener
 
-  def create_broadcaster
+  def create_broadcaster(options)
     broadcaster = UDPSocket.new
     broadcaster.setsockopt Socket::SOL_SOCKET, Socket::SO_BROADCAST, true
     broadcaster.setsockopt Socket::IPPROTO_IP, Socket::IP_MULTICAST_TTL, 1
+    broadcaster.setsockopt Socket::IPPROTO_IP, Socket::IP_MULTICAST_IF, IPAddr.new(options[:bind]).hton
     broadcaster
   end
   module_function :create_broadcaster

--- a/lib/ssdp/consumer.rb
+++ b/lib/ssdp/consumer.rb
@@ -5,7 +5,7 @@ module SSDP
   class Consumer
     def initialize(options={})
       @options = SSDP::DEFAULTS.merge options
-      @search_socket = SSDP.create_broadcaster
+      @search_socket = SSDP.create_broadcaster options
       @watch = {
         :socket   => nil,
         :thread   => nil,


### PR DESCRIPTION
My desktop is on multiple VLANs. SSDP search wasn't working because multicast addresses aren't associated with an interface via the route table like a non-multicast address.

This basically just tells the socket to use the interface associated with the bind address.

In my client, I loop through all local IP addresses and send a broadcast on each.

https://github.com/mikerodrigues/renstar