### PR TITLE
remove circular require to suppress warnings

### DIFF
--- a/lib/ssdp/consumer.rb
+++ b/lib/ssdp/consumer.rb
@@ -1,5 +1,4 @@
 require 'socket'
-require 'ssdp'
 
 module SSDP
   class Consumer

--- a/lib/ssdp/producer.rb
+++ b/lib/ssdp/producer.rb
@@ -1,6 +1,5 @@
 require 'socket'
 require 'securerandom'
-require 'ssdp'
 
 module SSDP
   class Producer


### PR DESCRIPTION
Kind of a nitpick, but I was cleaning up my warnings and noticed ssdp was throwing some of its own upon `require` due to circular require statements.

ssdp.rb was requiring consumer and producer, but they were each also requiring ssdp.

You can see the warnings with `ruby -w` or by setting `$VERBOSE=true`. Then just `require 'ssdp'` and you'll get a ton of warnings.